### PR TITLE
CleanupHandlerInterceptor needs check for null exception

### DIFF
--- a/blaze-ee-utils/src/main/java/com/blazebit/cdi/cleanup/CleanupHandlerInterceptor.java
+++ b/blaze-ee-utils/src/main/java/com/blazebit/cdi/cleanup/CleanupHandlerInterceptor.java
@@ -128,11 +128,15 @@ public class CleanupHandlerInterceptor implements Serializable {
                         if(m != null) {
                             final Class<?>[] parameterTypes = m.getParameterTypes();
                             if (parameterTypes.length == 1) {
-                                if (ReflectionUtils.isSubtype(exception.getClass(), parameterTypes[0])) {
-                                    m.invoke(target, exception);
-                                } else {
-                                    throw new IllegalArgumentException("Cleanup method with name " + cleanupClazz.getName() + " requires a parameter that is not a subtype of the exception class " + exception.getClass().getName());
-                                }
+                            	// Need to check for null exception
+                            	if(exception != null) {
+                            		// Check if exception type fits formal parameter type
+	                                if (!ReflectionUtils.isSubtype(exception.getClass(), parameterTypes[0])) {
+	                                    throw new IllegalArgumentException("Cleanup method with name " + cleanupClazz.getName() + " requires a parameter that is not a subtype of the exception class " + exception.getClass().getName());
+	                                } 	                                
+                            	}
+                            	// Invoked either with set or null exception
+                    		m.invoke(target, exception);
                             } else {
                                 m.invoke(target);
                             }


### PR DESCRIPTION
I have fixed an issue where a cleanup method with formal parameter (Exception type) cannot be invoked because no exception is given (null).
A NPE is thrown because the implemented type check (formal parameter type to exception type) does not check for null exception.